### PR TITLE
Fix PDF export with xhtml2pdf

### DIFF
--- a/markdown_viewer.py
+++ b/markdown_viewer.py
@@ -936,8 +936,10 @@ class MarkdownViewer(tk.Tk):
                     "<style>body{font-family:'STSong-Light';}</style></head>"
                     f"<body>{html_body}</body></html>"
                 )
+                import io
                 with open(file_path, "wb") as f:
-                    pisa_status = pisa.CreatePDF(html, dest=f, encoding="utf-8")
+                    html_bytes = io.BytesIO(html.encode("utf-8"))
+                    pisa_status = pisa.CreatePDF(html_bytes, dest=f)
                 if pisa_status.err:
                     raise Exception("PDF生成失败")
                 messagebox.showinfo("导出PDF", "PDF 导出成功！ 📄")


### PR DESCRIPTION
## Summary
- fix PDF export error by providing a BytesIO source to xhtml2pdf

## Testing
- `python -m py_compile markdown_viewer.py`

------
https://chatgpt.com/codex/tasks/task_e_68413b802ec88322b546ed659ba2426a