### PR TITLE
Fix: Resolve AttributeError in PDF export

### DIFF
--- a/markdown_viewer.py
+++ b/markdown_viewer.py
@@ -11,7 +11,7 @@ from reportlab.pdfbase.cidfonts import UnicodeCIDFont
 # Register a font that supports Chinese characters and set as default
 try:
     pdfmetrics.registerFont(UnicodeCIDFont("STSong-Light"))
-    pisa_default.DEFAULT_FONT = "STSong-Light"
+    # pisa_default.DEFAULT_FONT = "STSong-Light" # This line needs to be commented out
 except Exception:
     # If registration fails, fallback to the library default
     pass


### PR DESCRIPTION
The PDF export feature was encountering an "AttributeError: 'str' object has no attribute 'get'" error. This issue likely occurred because `pisa_default.DEFAULT_FONT` was globally set to a string value ("STSong-Light"). The `xhtml2pdf` library or its components might need a more complex object type or handle this global string default in a way that causes the error.

This commit resolves the issue by removing the global assignment to `pisa_default.DEFAULT_FONT`. The font "STSong-Light" continues to be registered through `pdfmetrics.registerFont(UnicodeCIDFont("STSong-Light"))` and is explicitly defined in the CSS style for the HTML content used in PDF generation. This method ensures proper rendering of Chinese characters in your PDF output, thereby preventing the AttributeError from occurring.